### PR TITLE
ports/rp2: Invalidate cache after clean to prevent hangs.

### DIFF
--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -132,6 +132,10 @@ static uint32_t begin_critical_flash_section(void) {
     uint8_t *maintenance_ptr = (uint8_t *)XIP_MAINTENANCE_BASE;
     for (int i = 1; i < 16 * 1024; i += 8) {
         maintenance_ptr[i] = 0;
+
+        // Must also invalidate the cache lines to prevent rare hangs
+        // See: https://forums.raspberrypi.com/viewtopic.php?t=378249)
+        maintenance_ptr[i - 1] = 0;
     }
     #endif
 


### PR DESCRIPTION
As documented here https://forums.raspberrypi.com/viewtopic.php?t=378249 when the XIP cache is very dirty (or under some more precise condition yet to be determined), cleaning the XIP cache can cause a hang.

Invalidating the lines after cleaning them appears to fix the hang.