### PR TITLE
rp2: Maximum PSRAM heap option.

### DIFF
--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -133,11 +133,12 @@ int main(int argc, char **argv) {
 
     #if MICROPY_HW_ENABLE_PSRAM
     if (psram_size) {
+        size_t psram_heap_size = MIN(psram_size, MICROPY_HW_PSRAM_MAX_HEAP_SIZE);
         #if MICROPY_GC_SPLIT_HEAP
         gc_init(&__GcHeapStart, &__GcHeapEnd);
-        gc_add((void *)PSRAM_BASE, (void *)(PSRAM_BASE + psram_size));
+        gc_add((void *)PSRAM_BASE, (void *)(PSRAM_BASE + psram_heap_size));
         #else
-        gc_init((void *)PSRAM_BASE, (void *)(PSRAM_BASE + psram_size));
+        gc_init((void *)PSRAM_BASE, (void *)(PSRAM_BASE + psram_heap_size));
         #endif
     } else {
         gc_init(&__GcHeapStart, &__GcHeapEnd);

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -85,6 +85,11 @@
 #define MICROPY_HW_ENABLE_PSRAM (0)
 #endif
 
+// Maximum amount of PSRAM to use for GC heap
+#ifndef MICROPY_HW_PSRAM_MAX_HEAP_SIZE
+#define MICROPY_HW_PSRAM_MAX_HEAP_SIZE (8 * 1024 * 1024)
+#endif
+
 // Memory allocation policies
 #if MICROPY_HW_ENABLE_PSRAM
 #define MICROPY_GC_STACK_ENTRY_TYPE             uint32_t


### PR DESCRIPTION
Add an option to allow a limit on the size of the PSRAM GC heap, so the rest of PSRAM can be used for other purposes.

I went for this for simplicity - and if we think it's a good idea it might be possible to get it accepted upstream.  A custom linker script like on Presto could give more flexibility but doesn't seem necessary right now.